### PR TITLE
Fix various 1.8.x-1.11.x incompatibilities

### DIFF
--- a/src/main/java/zone/rong/mixinbooter/MixinBooterMixinPlugin.java
+++ b/src/main/java/zone/rong/mixinbooter/MixinBooterMixinPlugin.java
@@ -21,8 +21,8 @@ public class MixinBooterMixinPlugin implements IMixinConfigPlugin {
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
         String version = MixinBooterPlugin.getMinecraftVersion();
         if (mixinClassName.contains("CrashReport")) {
-            // 1.8 & 1.8.8
-            return !version.endsWith(".8");
+            // 1.8.x
+            return !version.startsWith("1.8.");
         }
         return true;
     }

--- a/src/main/java/zone/rong/mixinbooter/MixinBooterPlugin.java
+++ b/src/main/java/zone/rong/mixinbooter/MixinBooterPlugin.java
@@ -4,6 +4,7 @@ import com.google.common.eventbus.EventBus;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
+import com.google.gson.stream.JsonReader;
 import com.llamalad7.mixinextras.MixinExtrasBootstrap;
 import net.minecraft.launchwrapper.Launch;
 import net.minecraftforge.fml.common.*;
@@ -112,7 +113,6 @@ public final class MixinBooterPlugin implements IFMLLoadingPlugin {
 
     private void gatherPresentMods() {
         Gson gson = new GsonBuilder().registerTypeAdapter(ArtifactVersion.class, new MockedArtifactVersionAdapter())
-                .setLenient()
                 .create();
         try {
             Enumeration<URL> resources = Launch.classLoader.getResources("mcmod.info");
@@ -145,7 +145,9 @@ public final class MixinBooterPlugin implements IFMLLoadingPlugin {
 
     private String parseMcmodInfo(Gson gson, URL url) {
         try {
-            JsonElement root = gson.fromJson(new InputStreamReader(url.openStream()), JsonElement.class);
+            JsonReader reader = new JsonReader(new InputStreamReader(url.openStream()));
+            reader.setLenient(true);
+            JsonElement root = gson.fromJson(reader, JsonElement.class);
             if (root.isJsonArray()) {
                 return gson.fromJson(new InputStreamReader(url.openStream()), ModMetadata[].class)[0].modId;
             } else {

--- a/src/main/java/zone/rong/mixinbooter/mixin/LoadControllerMixin.java
+++ b/src/main/java/zone/rong/mixinbooter/mixin/LoadControllerMixin.java
@@ -55,7 +55,7 @@ public class LoadControllerMixin {
                 for (ASMDataTable.ASMData annotated : annotatedData) {
                     try {
                         Class<?> clazz = Class.forName(annotated.getClassName());
-                        MixinBooterPlugin.LOGGER.info("Loading annotated late loader [{}] for its mixins.", clazz.getName());
+                        MixinBooterPlugin.logInfo("Loading annotated late loader [%s] for its mixins.", clazz.getName());
                         Object instance = clazz.newInstance();
                         if (instance instanceof ILateMixinLoader) {
                             lateLoaders.add((ILateMixinLoader) instance);
@@ -71,7 +71,7 @@ public class LoadControllerMixin {
                 for (ASMDataTable.ASMData itf : interfaceData) {
                     try {
                         Class<?> clazz = Class.forName(itf.getClassName().replace('/', '.'));
-                        MixinBooterPlugin.LOGGER.info("Loading late loader [{}] for its mixins.", clazz.getName());
+                        MixinBooterPlugin.logInfo("Loading late loader [%s] for its mixins.", clazz.getName());
                         lateLoaders.add((ILateMixinLoader) clazz.newInstance());
                     } catch (Throwable t) {
                         throw new RuntimeException("Unexpected error.", t);
@@ -87,9 +87,9 @@ public class LoadControllerMixin {
                         if (lateLoader.shouldMixinConfigQueue(context)) {
                             IMixinConfigHijacker hijacker = MixinBooterPlugin.getHijacker(mixinConfig);
                             if (hijacker != null) {
-                                MixinBooterPlugin.LOGGER.info("Mixin configuration [{}] intercepted by [{}].", mixinConfig, hijacker.getClass().getName());
+                                MixinBooterPlugin.logInfo("Mixin configuration [%s] intercepted by [{}].", mixinConfig, hijacker.getClass().getName());
                             } else {
-                                MixinBooterPlugin.LOGGER.info("Adding [{}] mixin configuration.", mixinConfig);
+                                MixinBooterPlugin.logInfo("Adding [%s] mixin configuration.", mixinConfig);
                                 Mixins.addConfiguration(mixinConfig);
                                 lateLoader.onMixinConfigQueued(context);
                             }
@@ -105,9 +105,9 @@ public class LoadControllerMixin {
                 for (String unconventionalConfig : unconventionalConfigs) {
                     IMixinConfigHijacker hijacker = MixinBooterPlugin.getHijacker(unconventionalConfig);
                     if (hijacker != null) {
-                        MixinBooterPlugin.LOGGER.info("Mixin configuration [{}] intercepted by [{}].", unconventionalConfig, hijacker.getClass().getName());
+                        MixinBooterPlugin.logInfo("Mixin configuration [%s] intercepted by [%s].", unconventionalConfig, hijacker.getClass().getName());
                     } else {
-                        MixinBooterPlugin.LOGGER.info("Adding [{}] mixin configuration.", unconventionalConfig);
+                        MixinBooterPlugin.logInfo("Adding [%s] mixin configuration.", unconventionalConfig);
                         Mixins.addConfiguration(unconventionalConfig);
                     }
                 }


### PR DESCRIPTION
Fixes #102 by utilizing `JsonReader#setLenient` instead.

Fixes #103 by introducing wrapper methods for logging which use the non-varargs version of the methods internally. This solution is preferable to #100 as [it does not eagerly perform string concatenation or formatting](https://logging.apache.org/log4j/2.x/manual/performance.html#api-concat).