### PR TITLE
Make IEarlyMixinLoader extend IFMLLoadingPlugin

### DIFF
--- a/src/main/java/zone/rong/mixinbooter/IEarlyMixinLoader.java
+++ b/src/main/java/zone/rong/mixinbooter/IEarlyMixinLoader.java
@@ -1,6 +1,9 @@
 package zone.rong.mixinbooter;
 
+import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
+
 import java.util.List;
+import java.util.Map;
 
 /**
  * Early mixins are defined as mixins that affects vanilla or forge classes.
@@ -8,10 +11,10 @@ import java.util.List;
  *
  * If you want to add mixins that affect mods, use {@link ILateMixinLoader}
  *
- * Implement this in your {@link net.minecraftforge.fml.relauncher.IFMLLoadingPlugin}.
+ * Extends {@link net.minecraftforge.fml.relauncher.IFMLLoadingPlugin}, making it a coremod.
  * Return all early mixin configs you want MixinBooter to queue and send to Mixin library.
  */
-public interface IEarlyMixinLoader {
+public interface IEarlyMixinLoader extends IFMLLoadingPlugin {
 
     /**
      * @return mixin configurations to be queued and sent to Mixin library.
@@ -54,4 +57,62 @@ public interface IEarlyMixinLoader {
      */
     default void onMixinConfigQueued(String mixinConfig) { }
 
+    /**
+     * Return a list of classes that implements the IClassTransformer interface
+     * @return a list of classes that implements the IClassTransformer interface
+     */
+    @Override
+    default String[] getASMTransformerClass() {
+        return null;
+    }
+
+    /**
+     * Return a class name that implements "ModContainer" for injection into the mod list
+     * The "getName" function should return a name that other mods can, if need be,
+     * depend on.
+     * Trivially, this modcontainer will be loaded before all regular mod containers,
+     * which means it will be forced to be "immutable" - not susceptible to normal
+     * sorting behaviour.
+     * All other mod behaviours are available however- this container can receive and handle
+     * normal loading events
+     */
+    @Override
+    default String getModContainerClass() {
+        return null;
+    }
+
+    /**
+     * Return the class name of an implementor of "IFMLCallHook", that will be run, in the
+     * main thread, to perform any additional setup this coremod may require. It will be
+     * run <strong>prior</strong> to Minecraft starting, so it CANNOT operate on minecraft
+     * itself. The game will deliberately crash if this code is detected to trigger a
+     * minecraft class loading
+     * TODO: implement crash ;)
+     */
+    @Override
+    default String getSetupClass() {
+        return null;
+    }
+
+    /**
+     * Inject coremod data into this coremod
+     * This data includes:
+     * "mcLocation" : the location of the minecraft directory,
+     * "coremodList" : the list of coremods
+     * "coremodLocation" : the file this coremod loaded from,
+     */
+    @Override
+    default void injectData(Map<String, Object> data) {
+        //NO-OP
+    }
+
+    /**
+     * Return an optional access transformer class for this coremod. It will be injected post-deobf
+     * so ensure your ATs conform to the new srgnames scheme.
+     * @return the name of an access transformer class or null if none is provided
+     */
+    @Override
+    default String getAccessTransformerClass() {
+        return null;
+    }
 }


### PR DESCRIPTION
This PR reduces necessary boilerplate by making IEarlyMixinLoader not reliant upon a second interface to work. 
It also removes the need to make 4 empty functions in every IEarlyMixinLoader by adding default functions to the interface. 
Finally, it adds the Javadocs for the IFMLLoadingPlugin methods to IEarlyMixinLoader, which might or might not be good 