### PR TITLE
Fix runtime test coremod loading & running on 1.8.9

### DIFF
--- a/.github/workflows/runtime-test.yml
+++ b/.github/workflows/runtime-test.yml
@@ -55,4 +55,3 @@ jobs:
           mc-runtime-test: lexforge
           java: 8
           dummy-assets: true
-          headlessmc-command: --jvm "-Dfml.coreMods.load=zone.rong.mixinbooter.MixinBooterPlugin"

--- a/src/main/java/zone/rong/mixinbooter/mixin/ASMModParserMixin.java
+++ b/src/main/java/zone/rong/mixinbooter/mixin/ASMModParserMixin.java
@@ -1,15 +1,15 @@
 package zone.rong.mixinbooter.mixin;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraftforge.fml.common.discovery.asm.ASMModParser;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Type;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import zone.rong.mixinbooter.fix.SuppressingClassReader;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 @Mixin(value = ASMModParser.class, remap = false)
@@ -18,20 +18,17 @@ public class ASMModParserMixin {
     @Shadow
     private Type asmType;
 
-    @WrapOperation(method = "<init>", at = @At(value = "NEW", target = "org/objectweb/asm/ClassReader"))
-    private ClassReader suppressClassReaderWhenReadingNewClasses(InputStream is, Operation<ClassReader> original) {
-        ClassReader reader;
+    @Redirect(method = "<init>", at = @At(value = "NEW", target = "org/objectweb/asm/ClassReader"))
+    private ClassReader suppressClassReaderWhenReadingNewClasses(InputStream is) throws IOException {
         try {
-            reader = original.call(is);
+            return new ClassReader(is);
         } catch (IllegalArgumentException e) {
             if (e.getMessage() == null) {
                 this.asmType = Type.VOID_TYPE;
-                reader = new SuppressingClassReader();
-            } else {
-                throw e;
+                return new SuppressingClassReader();
             }
+            throw e;
         }
-        return reader;
     }
 
 }


### PR DESCRIPTION
- The extra jvm arg in runtime test workflow pointing to `MixinBooterPlugin` is removed, because in production, coremod should be automatically discovered by Forge
- `ASMModParserMixin` now uses injector from base Mixin instead of MixinExtras, because it will cause crash on 1.8.9

[Related workflow output](https://github.com/ZZZank/MixinBooter/actions/runs/28732285707/job/85200059734 ), and crash report (Click to expand):

<details><summary>Details</summary>
<p>

```
WARNING: coremods are present:
  MixinBooter (!mixinbooter-11.1.jar)
Contact their authors BEFORE contacting forge

// Don't be sad, have a hug! <3

Time: 7/5/26 6:43 AM
Description: Initializing game

java.lang.NoClassDefFoundError: net/minecraftforge/fml/common/discovery/asm/ASMModParser
	at net.minecraftforge.fml.common.discovery.JarDiscoverer.discover(JarDiscoverer.java:69)
	at net.minecraftforge.fml.common.discovery.ContainerType.findMods(ContainerType.java:42)
	at net.minecraftforge.fml.common.discovery.ModCandidate.explore(ModCandidate.java:71)
	at net.minecraftforge.fml.common.discovery.ModDiscoverer.identifyMods(ModDiscoverer.java:134)
	at net.minecraftforge.fml.common.Loader.identifyMods(Loader.java:363)
	at net.minecraftforge.fml.common.Loader.loadMods(Loader.java:488)
	at net.minecraftforge.fml.client.FMLClientHandler.beginMinecraftLoading(FMLClientHandler.java:208)
	at net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:417)
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:329)
	at net.minecraft.client.main.Main.main(SourceFile:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
Caused by: java.lang.ClassNotFoundException: net.minecraftforge.fml.common.discovery.asm.ASMModParser
	at net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:191)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	... 16 more
Caused by: org.spongepowered.asm.mixin.transformer.throwables.MixinTransformerError: An unexpected critical error was encountered
	at org.spongepowered.asm.mixin.transformer.MixinProcessor.applyMixins(MixinProcessor.java:383)
	at org.spongepowered.asm.mixin.transformer.MixinTransformer.transformClass(MixinTransformer.java:237)
	at org.spongepowered.asm.mixin.transformer.MixinTransformer.transformClassBytes(MixinTransformer.java:202)
	at org.spongepowered.asm.mixin.transformer.Proxy.transform(Proxy.java:79)
	at net.minecraft.launchwrapper.LaunchClassLoader.runTransformers(LaunchClassLoader.java:279)
	at net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:176)
	... 18 more
Caused by: java.lang.ClassFormatError: StackMapTable format error: bad offset for Uninitialized in method com.llamalad7.mixinextras.utils.OperationUtils.generateSyntheticBridge([Lorg/objectweb/asm/Type;Lorg/objectweb/asm/Type;Z[Lorg/objectweb/asm/Type;Ljava/lang/String;Lorg/objectweb/asm/tree/ClassNode;Lcom/llamalad7/mixinextras/utils/OperationUtils$OperationContents;)Lorg/objectweb/asm/Handle;
	at com.llamalad7.mixinextras.injector.wrapoperation.WrapOperationInjector.makeOperation(WrapOperationInjector.java:122)
	at com.llamalad7.mixinextras.injector.wrapoperation.WrapOperationInjector.invokeHandler(WrapOperationInjector.java:107)
	at com.llamalad7.mixinextras.injector.wrapoperation.WrapOperationInjector.wrapOperation(WrapOperationInjector.java:70)
	at com.llamalad7.mixinextras.injector.wrapoperation.WrapOperationInjector.inject(WrapOperationInjector.java:61)
	at org.spongepowered.asm.mixin.injection.code.Injector.inject(Injector.java:284)
	at org.spongepowered.asm.mixin.injection.struct.InjectionInfo.inject(InjectionInfo.java:508)
	at com.llamalad7.mixinextras.injector.MixinExtrasLateInjectionInfo.lateInject(MixinExtrasLateInjectionInfo.java:52)
	at com.llamalad7.mixinextras.injector.LateInjectionApplicatorExtension.postApply(LateInjectionApplicatorExtension.java:40)
	at org.spongepowered.asm.mixin.transformer.ext.Extensions.postApply(Extensions.java:167)
	at org.spongepowered.asm.mixin.transformer.TargetClassContext.postApply(TargetClassContext.java:448)
	at org.spongepowered.asm.mixin.transformer.TargetClassContext.applyMixins(TargetClassContext.java:420)
	at org.spongepowered.asm.mixin.transformer.MixinProcessor.applyMixins(MixinProcessor.java:354)
	... 23 more
```

</p>
</details> 